### PR TITLE
support for differential backups; revamp of archive mode

### DIFF
--- a/bgbackup.sh
+++ b/bgbackup.sh
@@ -536,6 +536,19 @@ else
     exit 1
 fi
 
+# Check that we are not already running
+
+lockfile=/tmp/bgbackup.lock
+if [ -f $lockfile ]
+then
+    log_info "Another instance of bgbackup is already running. Exiting."
+    log_status=FAILED
+    mail_log
+    exit 1
+fi
+trap 'rm -f $lockfile' 0
+touch $lockfile
+
 mysqlcreate
 
 # Check that mysql client can connect

--- a/bgbackup.sh
+++ b/bgbackup.sh
@@ -79,16 +79,50 @@ function innocreate {
             fi
         fi
     elif [ "$bktype" = "archive" ] ; then
+
+        [ ! -d $backupdir/.lsn ] && mkdir $backupdir/.lsn
+        [ ! -d $backupdir/.lsn_full ] && mkdir $backupdir/.lsn_full
+
+	#if tempfolder is not set then  use /tmp
+	if [ -z "$tempfolder" ]	
+         then
+   		tempfolder=/tmp
+	fi
+ 
+	# verify the tempfolder directory exists
+	if [ ! -d "$tempfolder" ]
+	then
+    		log_info "Error: $tempfolder  directory not found"
+    		log_info "The configured directory for tempfolders does not exist. Please create this first."
+    		log_status=FAILED
+    		mail_log
+    		exit 1
+	fi
+
+	# verify user running script has permissions needed to write to tempfolder  directory
+	if [ ! -w "$tempfolder" ]; then
+    		log_info "Error: $tempfolder  directory is not writable."
+    		log_info "Verify the user running this script has write access to the configured tempfolder directory."
+    		log_status=FAILED
+    		mail_log
+    		exit 1
+	fi
+
+
         if [ "$(date +%A)" = "$fullbackday" ] || [ "$fullbackday" = "Everyday" ] ; then
             butype=Full
-            innocommand=$innocommand" /tmp --stream=$arctype --no-timestamp"
+            innocommand=$innocommand" $tempfolder --stream=$arctype --no-timestamp --extra-lsndir=$backupdir/.lsn_full"
             arcname="$backupdir/full-$dirdate.$arctype.gz"
         else
-            butype=Incremental
-            incbasecmd=$mysqlcommand" \"SELECT bulocation FROM $backuphistschema.backup_history WHERE status = 'SUCCEEDED' AND hostname = '$mhost' AND deleted_at = 0 ORDER BY start_time DESC LIMIT 1\" "
-            incbase=$(eval "$incbasecmd")
-            innocommand=$innocommand" /tmp --stream=$arctype --no-timestamp --incremental --incremental-basedir=$incbase"
-            arcname="$backupdir/inc-$dirdate.$arctype.gz"
+            if [ "$differential" = yes ] ; then
+                butype=Differential
+                innocommand=$innocommand" $tempfolder --stream=$arctype --no-timestamp --incremental --incremental-basedir=$backupdir/.lsn_full --extra-lsndir=$backupdir/.lsn"
+                arcname="$backupdir/diff-$dirdate.$arctype.gz"
+            else
+                butype=Incremental
+                innocommand=$innocommand" $tempfolder --stream=$arctype --no-timestamp --incremental --incremental-basedir=$backupdir/.lsn --extra-lsndir=$backupdir/.lsn"
+                arcname="$backupdir/inc-$dirdate.$arctype.gz"
+            fi
         fi
     fi
     if [ -n "$databases" ] && [ "$bktype" = "prepared-archive" ]; then innocommand=$innocommand" --databases=$databases"; fi
@@ -193,7 +227,7 @@ function mysqldumpcreate {
     mysqldumpcommand=$mysqldumpcommand" -u $backuphistuser"
     mysqldumpcommand=$mysqldumpcommand" -p$backuphistpass"
     mysqldumpcommand=$mysqldumpcommand" -h $backuphisthost"
-    [ -n "$backuphistport" ] && mysqldumpcommand=$mysqldumpcommand" -P $backuphistport"
+    [ -n "$backuphistport" ] && mysqldumpcommand=$myslqdumpcommand" -P $backuphistport"
     mysqldumpcommand=$mysqldumpcommand" $backuphistschema"
     mysqldumpcommand=$mysqldumpcommand" backup_history"
 }
@@ -383,7 +417,7 @@ function config_check {
         log_info "Archive backup type selected, disabling built-in compression."
         compress="no"
     fi
-    if [[ "$computil" != "gzip" && "$computil" != "pigz" ]] && [ "$bktype" = "archive" ]; then
+    if [[ "$computil" != "gzip" && "$computil" != "pigz"* ]] && [ "$bktype" = "archive" ]; then
         verbose="yes"
         log_info "Fatal: $computil compression method is unsupported."
         log_status=FAILED
@@ -416,6 +450,7 @@ function debugme {
     echo "cryptkey: " "$cryptkey"
     echo "nolock: " "$nolock"
     echo "compress: " "$compress"
+    echo "tempfolder: " "$tempfolder"
     echo "galera: " "$galera"
     echo "slave: " "$slave"
     echo "maillist: " "$maillist"


### PR DESCRIPTION
* revamped archive mode, including differential backups support.
When doing incrementals or differentials in archive mode, we need to just keep track of the xtrabackup_checkpoints file, which is saved in two hidden folders now. 
There are two because when running a differential backup  we need the ending LSN of the full backup to start from, while when running incremental backups we need the ending LSN of last (previous) incremental.
* support for options in compression tool
We can set "pigz -p XXX" in config file now.